### PR TITLE
U snapcraft.yaml: remove qt debug info 

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -219,7 +219,6 @@ parts:
        -sysconfdir /etc/xdg \
        -examplesdir /usr/lib/$SNAPCRAFT_ARCH_TRIPLET/qt5/examples \
        -release \
-       -force-debug-info \
        -opensource \
        -confirm-license \
        -system-freetype \


### PR DESCRIPTION

fix https://github.com/uglide/RedisDesktopManager/issues/5207